### PR TITLE
Add bmv2 SAI port attributes (num_active, port_list, dflt vlan, dflt_vrf)

### DIFF
--- a/dash-pipeline/SAI/templates/utils.cpp.j2
+++ b/dash-pipeline/SAI/templates/utils.cpp.j2
@@ -218,20 +218,71 @@ sai_status_t sai_create_switch_dummy(
     return SAI_STATUS_SUCCESS;
 }
 
-sai_status_t sai_get_switch_attribute_dummy(
+#define DASH_BMV2_NUM_PORTS 2 
+#define DASH_BMV2_DEFAULT_VLAN_ID (sai_object_id_t)((SAI_OBJECT_TYPE_VLAN<<48)+1)
+#define DASH_BMV2_DEFAULT_VRF_ID (sai_object_id_t)((SAI_OBJECT_TYPE_VIRTUAL_ROUTER<<48)+1)
+
+sai_object_id_t port_list[DASH_BMV2_NUM_PORTS] = {
+    (sai_object_id_t)((SAI_OBJECT_TYPE_PORT<<48) + 1),
+    (sai_object_id_t)((SAI_OBJECT_TYPE_PORT<<48) + 2)
+};
+
+sai_status_t sai_get_switch_attribute(
         _In_ sai_object_id_t switch_id,
         _In_ uint32_t attr_count,
         _Inout_ sai_attribute_t *attr_list) {
 
-    fprintf(stderr, "sai_get_switch_attribute_dummy()\n");
-    return SAI_STATUS_SUCCESS;
+    fprintf(stderr, "sai_get_switch_attribute()\n");
+    int i;
+    sai_attribute_t *attr = attr_list;
+    sai_object_list_t port_obj_list;
+    sai_object_id_t *objlist;
+    for (i = 0; i < attr_count ; i++, attr++) {
+        switch(attr->id) {
+        
+        case SAI_SWITCH_ATTR_NUMBER_OF_ACTIVE_PORTS:
+            attr->value.u32 = DASH_BMV2_NUM_PORTS;
+            fprintf(stderr, "  sai_get_switch_attribute() [%d] attr %d SAI_SWITCH_ATTR_NUMBER_OF_ACTIVE_PORTS = %d\n",
+                    i, attr->id, attr->value.u32);
+            return SAI_STATUS_SUCCESS;
+        
+        case SAI_SWITCH_ATTR_PORT_LIST:
+            // make a tmp port list, saiserver will free the memory
+            objlist = (sai_object_id_t *)malloc(sizeof(port_list));
+            memcpy(objlist, port_list, sizeof(port_list));
+            port_obj_list = {
+                .count = DASH_BMV2_NUM_PORTS,
+                .list = objlist
+            };                
+            attr->value.objlist = port_obj_list;
+            fprintf(stderr, "  sai_get_switch_attribute() [%d] attr %d SAI_SWITCH_ATTR_PORT_LIST = [%d objids]\n",
+                    i, attr->id, DASH_BMV2_NUM_PORTS);
+            return SAI_STATUS_SUCCESS;
+        
+        case SAI_SWITCH_ATTR_DEFAULT_VLAN_ID:
+            attr->value.oid = DASH_BMV2_DEFAULT_VLAN_ID;
+            fprintf(stderr, "  sai_get_switch_attribute() [%d] attr %d SAI_SWITCH_ATTR_DEFAULT_VLAN_ID = %lx\n",
+                    i, attr->id, attr->value.oid);
+            return SAI_STATUS_SUCCESS;
+        
+        case SAI_SWITCH_ATTR_DEFAULT_VIRTUAL_ROUTER_ID:
+            attr->value.oid = DASH_BMV2_DEFAULT_VRF_ID;
+            fprintf(stderr, "  sai_get_switch_attribute() [0] attr %d SAI_SWITCH_ATTR_DEFAULT_VIRTUAL_ROUTER_ID = %lx\n", attr->id, attr->value.oid);
+            return SAI_STATUS_SUCCESS;
+        
+        default:
+            fprintf(stderr, "  sai_get_switch_attribute() [0] attr %d is NOT SUPPORTED - returning SAI_STATUS_SUCCESS anyway\n", attr->id);
+            return SAI_STATUS_NOT_SUPPORTED;
+        }
+    }
+    return SAI_STATUS_NOT_SUPPORTED;
 }
 
 sai_switch_api_t sai_switch_api_impl = {
     .create_switch = sai_create_switch_dummy,
     .remove_switch = (void *)0,
     .set_switch_attribute = (void *)0,
-    .get_switch_attribute = sai_get_switch_attribute_dummy,
+    .get_switch_attribute = sai_get_switch_attribute,
     .get_switch_stats = (void *)0,
     .get_switch_stats_ext = (void *)0,
     .clear_switch_stats = (void *)0,

--- a/dash-pipeline/tests/saithrift/pytest/pytest.ini
+++ b/dash-pipeline/tests/saithrift/pytest/pytest.ini
@@ -2,5 +2,6 @@
 markers =
     bmv2:      test DASH bmv2 model
     saithrift: test DASH using saithrift API
+    switch:    test DASH SAI switch APIs
     vnet:      test DASH vnet scenarios
     

--- a/dash-pipeline/tests/saithrift/pytest/switch/test_saithrift_switch.py
+++ b/dash-pipeline/tests/saithrift/pytest/switch/test_saithrift_switch.py
@@ -6,10 +6,32 @@ from sai_thrift.ttypes  import *
        
 @pytest.mark.saithrift
 @pytest.mark.bmv2
-def test_sai_thrift_get_switch_attribute(saithrift_client):
+@pytest.mark.switch
+def test_sai_thrift_get_switch_attributes(saithrift_client):
     attr = sai_thrift_get_switch_attribute(
         saithrift_client, number_of_active_ports=True)
-    print ("switch_attributes = %s" % attr)
+    number_of_active_ports = attr['number_of_active_ports']
+
+    print ("number_of_active_ports = %d" % number_of_active_ports)
+    assert(number_of_active_ports != 0)
+
+    attr = sai_thrift_get_switch_attribute(
+        saithrift_client,
+        port_list=sai_thrift_object_list_t(idlist=[], count=int(number_of_active_ports)))
+    assert(number_of_active_ports == attr['port_list'].count)
+    port_list = attr['port_list'].idlist
+    print ("port list = ", port_list)
+
+    attr = sai_thrift_get_switch_attribute(
+        saithrift_client, default_vlan_id=True)
+    default_vlan_id = attr['default_vlan_id']
+    print ("default_vlan_id = %d" % default_vlan_id)
+    assert(default_vlan_id != 0)
+
+    attr = sai_thrift_get_switch_attribute(
+        saithrift_client, default_virtual_router_id=True)
+    default_virtual_router_id = attr['default_virtual_router_id']
+    print ("default_virtual_router_id = %d" % default_virtual_router_id)
+    assert(default_virtual_router_id != 0)
+    
     print ("test_sai_thrift_get_switch_attribute OK")
-
-


### PR DESCRIPTION
Please use this to make progress on https://github.com/PLVision/DASH/issues/29 and https://github.com/Azure/DASH/issues/235. I did not implement any CPU port-related attributes. bmv2 doesn't support any CPU port at this time - it's not even on the plan.

I added tests to `dash-pipeline/tests/saithrift/pytest/test_saithrift_switch.py`, here is the partial output:
```
dash-pipeline$ make run-saithrift-pytests
...
switch/test_saithrift_switch.py Called fixture saithrift_client()
making thrift connection to localhost:9092
sai-thrift connection established with localhost:9092
number_of_active_ports = 2
port list =  [1, 2]
default_vlan_id = 1
default_virtual_router_id = 1
test_sai_thrift_get_switch_attribute OK
```